### PR TITLE
Remove npm task

### DIFF
--- a/roles/web/tasks/node.yml
+++ b/roles/web/tasks/node.yml
@@ -16,6 +16,3 @@
 
 - name: Node.js | Install nodejs and npm
   action: apt pkg=nodejs state=latest
-
-- name: Node.js | Install required npm packages
-  action: command npm install -g bower grunt-cli jshint yo


### PR DESCRIPTION
Removing `npm install` task, basically because we're not using those packages within the vm anymore.
