### PR TITLE
MANATI-VM: Fix image styles with nginx

### DIFF
--- a/provisioning/templates/nginx-vhost.conf.j2
+++ b/provisioning/templates/nginx-vhost.conf.j2
@@ -41,7 +41,7 @@ server {
         rewrite ^ /index.php;
     }
 
-    location ~ ^/sites/.*/files/styles/ {
+    location ~* /files/styles/ {
         try_files $uri @rewrite;
     }
 

--- a/provisioning/templates/nginx-vhost.conf.j2
+++ b/provisioning/templates/nginx-vhost.conf.j2
@@ -41,7 +41,7 @@ server {
         rewrite ^ /index.php;
     }
 
-    location ~* /files/styles/ {
+    location ~ /sites/.*/files/styles/ {
         try_files $uri @rewrite;
     }
 


### PR DESCRIPTION
Steps to test:

- Go to an Existing site.
- Go to an existing node that contains images.
- The images should be visible and formatted by their image style.