### PR TITLE
Provisioning issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ This is a lamp/lemp development machine.
 
       vagrant up
 
+## Known issues
+
+- Once you've built everything it is possible that your machine runs the most recent version of PHP in the cli, no matter what you wrote in the config.yml, so if you want the cli to be the same, you'll have to do it manually for example, if you want to have the cli running PHP 5.6, then you could do so by running:
+
+      vagrant ssh
+      sudo update-alternatives --set php /usr/bin/php5.6
+
 ## Useful information
 
 If you need to provision again (or have edited config.yml to add sites/databases/hosts), run:

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -24,7 +24,7 @@
 - src: geerlingguy.blackfire
   version: 1.0.0
 - src: geerlingguy.varnish
-  version: 1.8.1
+  version: 2.1.1
 - src: geerlingguy.java
   version: 1.7.2
 - src: geerlingguy.solr

--- a/provisioning/vars/main.yml
+++ b/provisioning/vars/main.yml
@@ -46,9 +46,9 @@ php_packages:
   - php{{ php_version }}-sqlite3
   - php{{ php_version }}-xml
   - php-pear
-  - php7.1-xml
-  - php7.1-mysql
-  - php7.1-mbstring
+  - php7.2-xml
+  - php7.2-mysql
+  - php7.2-mbstring
   - libpcre3-dev
 php_conf_paths:
   - /etc/php/{{ php_version }}/fpm


### PR DESCRIPTION
## Description

- Provisioning was failing because of:

```
FAILED! => {"changed": false, "failed": true, "msg": "Failed to download key at https://repo.varnish-cache.org/GPG-key.txt: HTTP Error 410: repo"}
```

on task "Add varnish apt key" as the file was removed and we were still on an outdated version of varnish, so here we updated that version to 2.1.1.

- On the build process, we automatically use the most recent version of PHP (in this case 7.2) but in main.yml we are trying to install php packages for php 7.1, so here I updated those packages to use 7.2.

- As the cli is using automatically the most recent php version instead of the one specified in the config.yml, I added a piece in the documentation about how to solve that issue manually.